### PR TITLE
Updated react-hot-loader to newer version

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "node-sass": "^4.7.2",
     "ps-node": "^0.1.6",
     "raw-loader": "^0.5.1",
-    "react-hot-loader": "^3.1.3",
+    "react-hot-loader": "^4.7.1",
     "redisdown": "^0.1.12",
     "rimraf": "~2.6.2",
     "rocksdb": "^1.1.0",


### PR DESCRIPTION
Was receiving a very strange bug and I believe the culprit was 'react-hot-loader', here are is a StackOverflow issues, which describe a very similar problem.

https://stackoverflow.com/questions/50162522/cant-call-setstate-on-a-component-that-is-not-yet-mounted

Updating to the latest version solved the issue for me as well.

